### PR TITLE
Force exit after all tests are completed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
           - lens-ref: HEAD
             node-version: 16
             script: tools/integration_test.sh
-          - lens-ref: v6.4.0-beta.5
+          - lens-ref: v6.4.0-beta.16
             node-version: 16
             script: tools/integration_test.sh
           - lens-ref: v6.4.0-alpha.4

--- a/tools/integration_test.sh
+++ b/tools/integration_test.sh
@@ -11,13 +11,18 @@ cp tools/extensions.tests.ts ${DIR}/lens/packages/open-lens/integration/__tests_
 TARGET_FILE="${DIR}/lens/packages/open-lens/package.json" node tools/remove_extra_lens_targets.js
 
 pushd ${DIR}/lens
-    yarn install --frozen-lockfile
-    yarn run build:app
+    if [ -f "package-lock.json" ]; then
+        npm ci
+    else
+        npm install
+    fi
+
+    npm run build:app
 
     # If left present, the snap package will be mistaken for an obsolete Jest snapshot
-    rm packages/open-lens/dist/*.snap
+    rm -f packages/open-lens/dist/*.snap
 
-    cd packages/open-lens && npx jest -- integration/__tests__/extensions.tests.ts
+    cd packages/open-lens && npx jest --forceExit -- integration/__tests__/extensions.tests.ts
 popd
 
 rm -rf ${DIR}


### PR DESCRIPTION
This change should allow integration tests to run properly until https://github.com/lensapp/lens/issues/7207 is fixed.