### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This OpenLens extension adds back the node and pod menu functionality that was r
 
 # Installing this extension
 
-In OpenLens, navigate to the Extensions list. In the text box, enter the name of this plugin:
+In OpenLens, navigate to Menu > Extensions. In the text box, enter the name of this plugin:
 
 ```
 @alebcay/openlens-node-pod-menu


### PR DESCRIPTION
fix #27, I guess the exact location differs per OS, it's OpenLens > Extensions on macOS, hence just menu